### PR TITLE
Return empty string when there are no verified Twitter accounts

### DIFF
--- a/platform/twitter.rb
+++ b/platform/twitter.rb
@@ -23,7 +23,7 @@ module Platform
     # This is wrapped in something to check the rate limiting
     # It's not the prettiest but should stop us from breaking
     def account_for(person)
-      client.user_search(person).find(&:verified?).uri.to_s
+      client.user_search(person).find(&:verified?)&.uri.to_s
     rescue ::Twitter::Error::TooManyRequests => error
       puts 'Too many requests for twitter, sleeping for a bit...'
       sleep(error.rate_limit.reset_in + 1)

--- a/spec/platform/twitter_spec.rb
+++ b/spec/platform/twitter_spec.rb
@@ -3,18 +3,33 @@
 require_relative '../../platform/twitter'
 
 describe Platform::Twitter do
-  subject { described_class.new }
+  let(:twitter_platform) { described_class.new }
 
   describe '#account_for' do
-    let(:expected) { 'https://twitter.com/DILLONFRANCIS' }
-    it 'returns the correct account' do
-      expect(subject.account_for('Dillon Francis')).to eq(expected)
+    subject { twitter_platform.account_for(person) }
+
+    context 'when a verified account exists' do
+      let(:person) { 'Dillon Francis' }
+      let(:expected) { 'https://twitter.com/DILLONFRANCIS' }
+
+      it 'returns the correct account' do
+        expect(subject).to eq(expected)
+      end
+    end
+
+    context 'when there is no verified account' do
+      let(:person) { 'blueyhuey' }
+      let(:expected) { '' }
+
+      it 'returns an empty string' do
+        expect(subject).to eq(expected)
+      end
     end
   end
 
   describe '#count_for' do
     it 'returns an integer' do
-      expect(subject.count_for('Rick and Morty')).to be_an Integer
+      expect(twitter_platform.count_for('Rick and Morty')).to be_an Integer
     end
   end
 end


### PR DESCRIPTION
Before this would throw a `NoMethodError` since we would try to `to_s` a nil.
This also includes a spec for this case.